### PR TITLE
Make sure we call setlocale

### DIFF
--- a/cgdb/cgdb.cpp
+++ b/cgdb/cgdb.cpp
@@ -58,6 +58,10 @@
 #include <ctype.h>
 #endif
 
+#if HAVE_LOCALE_H
+#include <locale.h>
+#endif
+
 #include <string>
 
 #define __STDC_FORMAT_MACROS
@@ -1077,6 +1081,8 @@ int main(int argc, char *argv[])
     }
 
     /* From here on, the logger is initialized */
+
+    setlocale(LC_CTYPE, "");
 
     if (tty_cbreak(STDIN_FILENO, &term_attributes) == -1) {
         clog_error(CLOG_CGDB, "tty_cbreak error");

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AC_CHECK_HEADERS([regex.h],,[AC_MSG_ERROR([CGDB requires regex.h to build.])])
 AC_CHECK_HEADERS([curses.h],,[
    AC_CHECK_HEADERS([ncurses/curses.h],,[
       AC_MSG_ERROR([CGDB requires curses.h or ncurses/curses.h to build.])])])
+AC_CHECK_HEADERS([locale.h],,[AC_MSG_ERROR([CGDB requires locale.h to build.])])
 
 dnl Check for getopt.h, If this is here then getopt_long can be used.
 AC_CHECK_HEADERS([getopt.h],


### PR DESCRIPTION
Before #330, this was done for use by readline, through the chain of calls rl_initialize -> _rl_reset_locale -> _rl_init_locale -> setlocale

Fixes #342

